### PR TITLE
Deploy #2 - Permitir outros servidores SMTP

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -362,3 +362,5 @@ MigrationBackup/
 # Fody - auto-generated XML schema
 FodyWeavers.xsd
 /dominio/UsuarioDNIT.cs
+
+app/build

--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ _Observação_: No EscolaServices, é necessario adicionar um arquivo ".env" den
 
     - EMAIL_SERVICE_ADDRESS : email usado para enviar a mensagem.
     - EMAIL_SERVICE_PASSWORD: senha do email acima.
+    - EMAIL_SERVICE_SMTP: endereco do servidor smtp
     - EMAIL_DNIT: email que receberá a mensagem.
 
 #### Windows e MacOs

--- a/service/SmtpClientWrapper.cs
+++ b/service/SmtpClientWrapper.cs
@@ -15,10 +15,11 @@ namespace service
 
         public SmtpClientWrapper()
         {
-            string emailRemetente = Environment.GetEnvironmentVariable("EMAIL_SERVICE_ADDRESS");
-            string senhaRemetente = Environment.GetEnvironmentVariable("EMAIL_SERVICE_PASSWORD");
+            var emailRemetente = Environment.GetEnvironmentVariable("EMAIL_SERVICE_ADDRESS");
+            var senhaRemetente = Environment.GetEnvironmentVariable("EMAIL_SERVICE_PASSWORD");
+            var smtpDomain = Environment.GetEnvironmentVariable("EMAIL_SERVICE_SMTP") ?? "smtp-mail.outlook.com";
 
-            smtpClient = new SmtpClient("smtp-mail.outlook.com")
+            smtpClient = new SmtpClient(smtpDomain)
             {
                 Port = 587,
                 Credentials = new NetworkCredential(emailRemetente, senhaRemetente),


### PR DESCRIPTION
## Descrição

 - O endereço do smtp foi generalizado, permitindo utilizar outros servidores de smtp, como o do google.
 
## Para revisar

- A mudança já está implantada. Para testar, solicite uma ação e verifique a chegada do email. https://dnit.eps-fga.live/solicitacaoAcao
![image](https://github.com/fga-eps-mds/2023.2-Dnit-EscolaService/assets/54081877/79776d96-513a-43eb-af04-a5abc428f85a)

- Para teste local:
    - Adicione na pasta "app"  um, arquivo .env com as seguintes variaveis:
        - EMAIL_SERVICE_ADDRESS : email usado para enviar a mensagem.
        - EMAIL_SERVICE_PASSWORD: senha do email acima.
        - EMAIL_SERVICE_SMTP: endereço do smtp
       - EMAIL_DNIT: email que receberá a mensagem. 
   - Realize uma Solicitação ação ao DNIT e veja o email chegar
